### PR TITLE
JWT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ build/Release
 # see https://npmjs.org/doc/faq.html#Should-I-check-my-node_modules-folder-into-git
 node_modules
 /test/browser/test.js
+/test/browser/functional.js

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,7 +6,7 @@ var derequire = require('gulp-derequire');
 var rename = require('gulp-rename');
 var runSequence = require('run-sequence');
 var http = require('http');
-var BrowserStackTunnel = require('browserstacktunnel-wrapper');
+var browserstack = require('browserstack-local');
 
 var config = require('./test/config');
 
@@ -23,12 +23,12 @@ gulp.task('build', function() {
 
 gulp.task('test', function(callback) {
   runSequence(
-    ['build-browser-test', 'start-test-server', 'start-browserstack-tunnel'],
+    ['build-browser-test', 'start-test-server', 'start-browserstack-local'],
     'run-node-test',
     'run-browser-test',
     function() {
       runSequence(
-        ['stop-test-server', 'stop-browserstack-tunnel'],
+        ['stop-test-server', 'stop-browserstack-local'],
         callback);
     }
   );
@@ -48,11 +48,11 @@ gulp.task('node-test', function(callback) {
 
 gulp.task('browser-test', function(callback) {
   runSequence(
-    ['build-browser-test', 'start-test-server', 'start-browserstack-tunnel'],
+    ['build-browser-test', 'start-test-server', 'start-browserstack-local'],
     'run-browser-test',
     function() {
       runSequence(
-        ['stop-test-server', 'stop-browserstack-tunnel'],
+        ['stop-test-server', 'stop-browserstack-local'],
         callback);
     }
   );
@@ -88,21 +88,18 @@ gulp.task('stop-test-server', function(callback) {
   test_server.close(callback);
 });
 
-var browserstack_tunnel;
-gulp.task('start-browserstack-tunnel', function(callback) {
-  browserstack_tunnel = new BrowserStackTunnel({
-    key: 'TODO',
-    v: true
-  });
-
-  browserstack_tunnel.start(function(err) {
-    if (!err) gutil.log('BrowserStack tunnel started');
+var bs_local;
+gulp.task('start-browserstack-local', function(callback) {
+  bs_local = new browserstack.Local();
+  var bs_local_args = {'key': 'TODO', force: true, verbose: true};
+  bs_local.start(bs_local_args, function(err) {
+    if (!err) gutil.log('Started BrowserStackLocal');
     callback(err);
   });
 });
 
-gulp.task('stop-browserstack-tunnel', function(callback) {
-  browserstack_tunnel.stop(callback);
+gulp.task('stop-browserstack-local', function(callback) {
+  bs_local.stop(callback);
 });
 
 gulp.task('run-node-test', function(callback) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -79,7 +79,7 @@ gulp.task('start-test-server', function(callback) {
     .createServer(config.routes)
     .listen(config.port, function() {
       gutil.log('Test server started on', gutil.colors.green(config.host));
-      gutil.log('Run manual tests on', gutil.colors.green(config.host + '/test/browser/test.html'));
+      gutil.log('Run manual tests on', gutil.colors.green(config.testPage));
       callback();
     });
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -66,9 +66,22 @@ gulp.task('test-server', function(callback) {
 
 // TASKS
 
-gulp.task('build-browser-test', function() {
+gulp.task('build-browser-test', function(callback) {
+  runSequence(
+    ['build-browser-unit-test', 'build-browser-functional-test'],
+    callback);
+});
+
+gulp.task('build-browser-unit-test', function() {
   return gulp
     .src('./test/test.js')
+    .pipe(browserify())
+    .pipe(gulp.dest('./test/browser'));
+});
+
+gulp.task('build-browser-functional-test', function() {
+  return gulp
+    .src('./test/tests/functional.js')
     .pipe(browserify())
     .pipe(gulp.dest('./test/browser'));
 });
@@ -79,7 +92,8 @@ gulp.task('start-test-server', function(callback) {
     .createServer(config.routes)
     .listen(config.port, function() {
       gutil.log('Test server started on', gutil.colors.green(config.host));
-      gutil.log('Run manual tests on', gutil.colors.green(config.testPage));
+      gutil.log('Run unit tests on', gutil.colors.green(config.testPage));
+      gutil.log('Run functional tests on', gutil.colors.green(config.functionalTestPage));
       callback();
     });
 });

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var API_URLS = {
-  test:       'http://localhost:8081/api/v1',
+  test:       'http://universe-js.test:8081/api/v1',
   staging:    'https://staging.services.sparkart.net/api/v1',
   production: 'https://services.sparkart.net/api/v1'
 };

--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ var requestResource = function(method, endpoint, payload, callback) {
   const self = this;
 
   validateTokens.call(self, function(err) {
-    const cb = (err, response) => callback(err, response ? response.data : undefined);
+    function cb(err, response) {callback(err, response ? response.data : undefined)};
     const resource = new Resource(self.resource(endpoint), self.resources_options);
     if (method === 'get') {
       resource.get(cb);

--- a/index.js
+++ b/index.js
@@ -135,7 +135,7 @@ var requestResource = function(method, endpoint, payload, callback) {
 var validateTokens = function(callback) {
   const now = new Date().getTime();
 
-  if (localStorage.getItem('universeAccessToken') && now < localStorage.getItem('universeAccessTokenExpiration')) {
+  if (localStorage.getItem('universeAccessToken') && now < (localStorage.getItem('universeAccessTokenExpiration') || 0)) {
     // Valid access token
     return callback();
   } else {
@@ -143,7 +143,7 @@ var validateTokens = function(callback) {
     localStorage.removeItem('universeAccessTokenExpiration');
   }
 
-  if (!localStorage.getItem('universeRefreshToken') || now >= (localStorage.getItem('universeRefreshTokenExpiration') || Infinity)) {
+  if (!localStorage.getItem('universeRefreshToken') || now >= (localStorage.getItem('universeRefreshTokenExpiration') || 0)) {
     // Missing or expired refresh token
     localStorage.removeItem('universeRefreshToken');
     localStorage.removeItem('universeRefreshTokenExpiration');

--- a/login/closePromptPopup.hbs
+++ b/login/closePromptPopup.hbs
@@ -9,12 +9,16 @@
     // storing the auth tokens, closing the popup and navigating to the final
     // destination.
 
-    localStorage.setItem('universeAccessToken', decodeURIComponent((window.location.search.match(/[\?&]access_token=([^&#$]+)/) || [undefined, ''])[1]));
-    localStorage.setItem('universeAccessTokenExpiration', decodeURIComponent((window.location.search.match(/[\?&]access_token_expiration=([^&#$]+)/) || [undefined, '0'])[1]) * 1000);
-    localStorage.setItem('universeRefreshToken', decodeURIComponent((window.location.search.match(/[\?&]refresh_token=([^&#$]+)/) || [undefined, ''])[1]));
-    localStorage.setItem('universeRefreshTokenExpiration', decodeURIComponent((window.location.search.match(/[\?&]refresh_token_expiration=([^&#$]+)/) || [undefined, '0'])[1]) * 1000);
+    function qsParam(name, defaultValue) {
+      return decodeURIComponent((window.location.search.match(new RegExp('[\\?&]' + name + '=([^&#$]+)')) || [undefined, defaultValue || ''])[1]);
+    };
 
-    const redirect = localStorage.getItem('universeLoginRedirect') || '/';
+    localStorage.setItem('universeAccessToken', qsParam('access_token'));
+    localStorage.setItem('universeAccessTokenExpiration', qsParam('access_token_expiration', '0') * 1000);
+    localStorage.setItem('universeRefreshToken', qsParam('refresh_token'));
+    localStorage.setItem('universeRefreshTokenExpiration', qsParam('refresh_token_expiration', '0') * 1000);
+
+    const redirect = localStorage.getItem('universeLoginRedirect') || qsParam('redirect', '/');
     localStorage.removeItem('universeLoginRedirect');
 
     if (window.opener) {

--- a/login/closePromptPopup.hbs
+++ b/login/closePromptPopup.hbs
@@ -9,13 +9,13 @@
     // storing the auth tokens, closing the popup and navigating to the final
     // destination.
 
-    sessionStorage.setItem('universeAccessToken', decodeURIComponent((window.location.search.match(/[\?&]access_token=([^&#$]+)/) || [undefined, ''])[1]));
-    sessionStorage.setItem('universeAccessTokenExpiration', decodeURIComponent((window.location.search.match(/[\?&]access_token_expires_at=([^&#$]+)/) || [undefined, ''])[1]));
-    sessionStorage.setItem('universeRefreshToken', decodeURIComponent((window.location.search.match(/[\?&]refresh_token=([^&#$]+)/) || [undefined, ''])[1]));
-    sessionStorage.setItem('universeRefreshTokenExpiration', decodeURIComponent((window.location.search.match(/[\?&]refresh_token_expires_at=([^&#$]+)/) || [undefined, ''])[1]));
+    localStorage.setItem('universeAccessToken', decodeURIComponent((window.location.search.match(/[\?&]access_token=([^&#$]+)/) || [undefined, ''])[1]));
+    localStorage.setItem('universeAccessTokenExpiration', decodeURIComponent((window.location.search.match(/[\?&]access_token_expiration=([^&#$]+)/) || [undefined, '0'])[1]) * 1000);
+    localStorage.setItem('universeRefreshToken', decodeURIComponent((window.location.search.match(/[\?&]refresh_token=([^&#$]+)/) || [undefined, ''])[1]));
+    localStorage.setItem('universeRefreshTokenExpiration', decodeURIComponent((window.location.search.match(/[\?&]refresh_token_expiration=([^&#$]+)/) || [undefined, '0'])[1]) * 1000);
 
-    const redirect = sessionStorage.getItem('universeLoginRedirect') || '/';
-    sessionStorage.removeItem('universeLoginRedirect');
+    const redirect = localStorage.getItem('universeLoginRedirect') || '/';
+    localStorage.removeItem('universeLoginRedirect');
 
     if (window.opener) {
       window.opener.location.href = redirect;

--- a/login/closePromptPopup.hbs
+++ b/login/closePromptPopup.hbs
@@ -6,18 +6,22 @@
 
     // After a successful login in the popup the parent window is redirected by
     // Universe to /login/reload (hardcoded path). This page is responsible for
-    // closing the popup and navigating to the final destination.
+    // storing the auth tokens, closing the popup and navigating to the final
+    // destination.
 
-    // Copied from https://wzrd.in/standalone/cookie@0.1.2, until HTTPS is enabled on browserify.sparkart.net
-    !function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var r;r="undefined"!=typeof window?window:"undefined"!=typeof global?global:"undefined"!=typeof self?self:this,r.cookie=e()}}(function(){return function e(r,n,o){function t(u,f){if(!n[u]){if(!r[u]){var a="function"==typeof require&&require;if(!f&&a)return a(u,!0);if(i)return i(u,!0);var p=new Error("Cannot find module '"+u+"'");throw p.code="MODULE_NOT_FOUND",p}var s=n[u]={exports:{}};r[u][0].call(s.exports,function(e){var n=r[u][1][e];return t(n?n:e)},s,s.exports,e,r,n,o)}return n[u].exports}for(var i="function"==typeof require&&require,u=0;u<o.length;u++)t(o[u]);return t}({1:[function(e,r,n){var o=function(e,r,n){n=n||{};var o=n.encode||i,t=[e+"="+o(r)];if(null!=n.maxAge){var u=n.maxAge-0;if(isNaN(u))throw new Error("maxAge should be a Number");t.push("Max-Age="+u)}return n.domain&&t.push("Domain="+n.domain),n.path&&t.push("Path="+n.path),n.expires&&t.push("Expires="+n.expires.toUTCString()),n.httpOnly&&t.push("HttpOnly"),n.secure&&t.push("Secure"),t.join("; ")},t=function(e,r){r=r||{};var n={},o=e.split(/; */),t=r.decode||u;return o.forEach(function(e){var r=e.indexOf("=");if(!(r<0)){var o=e.substr(0,r).trim(),i=e.substr(++r,e.length).trim();if('"'==i[0]&&(i=i.slice(1,-1)),void 0==n[o])try{n[o]=t(i)}catch(e){n[o]=i}}}),n},i=encodeURIComponent,u=decodeURIComponent;r.exports.serialize=o,r.exports.parse=t},{}]},{},[1])(1)});
+    sessionStorage.setItem('universeAccessToken', decodeURIComponent((window.location.search.match(/[\?&]access_token=([^&#$]+)/) || [undefined, ''])[1]));
+    sessionStorage.setItem('universeAccessTokenExpiration', decodeURIComponent((window.location.search.match(/[\?&]access_token_expires_at=([^&#$]+)/) || [undefined, ''])[1]));
+    sessionStorage.setItem('universeRefreshToken', decodeURIComponent((window.location.search.match(/[\?&]refresh_token=([^&#$]+)/) || [undefined, ''])[1]));
+    sessionStorage.setItem('universeRefreshTokenExpiration', decodeURIComponent((window.location.search.match(/[\?&]refresh_token_expires_at=([^&#$]+)/) || [undefined, ''])[1]));
 
-    var redirect = cookie.parse(document.cookie).redirect;
+    const redirect = sessionStorage.getItem('universeLoginRedirect') || '/';
+    sessionStorage.removeItem('universeLoginRedirect');
 
-    document.cookie = cookie.serialize('redirect', false, {path: '/login', expires: new Date('Thu, 01 Jan 1970 00:00:00 GMT')});
-
-    if( window.opener && redirect ){
+    if (window.opener) {
       window.opener.location.href = redirect;
       window.close();
+    } else {
+      window.location.href = redirect;
     }
 
   </script>

--- a/login/login.js
+++ b/login/login.js
@@ -1,4 +1,3 @@
-var cookie = require('cookie');
 var Delegate = require('dom-delegate');
 var qs = require('query-string');
 
@@ -60,17 +59,18 @@ function prompt (fanclub, options, processor) {
     options = undefined;
   }
 
+  // Set the "popup=1" option even for mobile, to force a redirect to /login/reload,
+  // which is the page responsible with storing the returned Universe tokens
+  var login = config(fanclub, options, true, processor);
+
+  // Set desired final destination in session storage to preserve through intermediary redirects
+  module.exports.setLoginRedirect(login.redirect);
+
   if (util.isMobile) {
-    module.exports.setUrl(config(fanclub, options, false, processor).url);
+    module.exports.setUrl(login.url);
   } else {
-    var login = config(fanclub, options, true, processor);
-
-    // Set desired final destination in a cookie to preserve through intermediary redirects
-    module.exports.setCookie(login.redirect);
-
     popup(login.url);
   }
-
 };
 
 /**
@@ -138,7 +138,7 @@ module.exports = {
 
   // Exposed for testing
   setUrl: function(url) {window.location.href = url},
-  setCookie: function(url) {document.cookie = cookie.serialize('redirect', url, {path: '/login'})},
+  setLoginRedirect: function(url) {sessionStorage.setItem('universeLoginRedirect', url)},
   openUrl: function(url, options) {
     // HACK: Required so the referrer is set properly in IE
     var wnd = window.open('', 'universeLogin', qs.stringify(options).replace(/&/g, ','));

--- a/login/login.js
+++ b/login/login.js
@@ -27,10 +27,10 @@ function linkify (fanclub, scope, processor) {
       event.preventDefault();
       module.exports.prompt(fanclub, url, processor);
     } else if (url.match('logout')) {
-      sessionStorage.removeItem('universeAccessToken');
-      sessionStorage.removeItem('universeAccessTokenExpiration');
-      sessionStorage.removeItem('universeRefreshToken');
-      sessionStorage.removeItem('universeRefreshTokenExpiration');
+      localStorage.removeItem('universeAccessToken');
+      localStorage.removeItem('universeAccessTokenExpiration');
+      localStorage.removeItem('universeRefreshToken');
+      localStorage.removeItem('universeRefreshTokenExpiration');
     }
   });
 };
@@ -68,7 +68,7 @@ function prompt (fanclub, options, processor) {
   // which is the page responsible with storing the returned Universe tokens
   var login = config(fanclub, options, true, processor);
 
-  // Set desired final destination in session storage to preserve through intermediary redirects
+  // Set desired final destination in local storage to preserve through intermediary redirects
   module.exports.setLoginRedirect(login.redirect);
 
   if (util.isMobile) {
@@ -143,7 +143,7 @@ module.exports = {
 
   // Exposed for testing
   setUrl: function(url) {window.location.href = url},
-  setLoginRedirect: function(url) {sessionStorage.setItem('universeLoginRedirect', url)},
+  setLoginRedirect: function(url) {localStorage.setItem('universeLoginRedirect', url)},
   openUrl: function(url, options) {
     // HACK: Required so the referrer is set properly in IE
     var wnd = window.open('', 'universeLogin', qs.stringify(options).replace(/&/g, ','));

--- a/login/login.js
+++ b/login/login.js
@@ -1,8 +1,6 @@
 var Delegate = require('dom-delegate');
 var qs = require('query-string');
 
-var util = require('../lib/util');
-
 /**
  * Override login links, including those added dynamically
  * @param {object} fanclub - universe /api/v1/fanclub data
@@ -64,18 +62,14 @@ function prompt (fanclub, options, processor) {
     options = undefined;
   }
 
-  // Set the "popup=1" option even for mobile, to force a redirect to /login/reload,
+  // Set the "popup=1" option, to force a redirect to /login/reload,
   // which is the page responsible with storing the returned Universe tokens
   var login = config(fanclub, options, true, processor);
 
   // Set desired final destination in local storage to preserve through intermediary redirects
   module.exports.setLoginRedirect(login.redirect);
 
-  if (util.isMobile) {
-    module.exports.setUrl(login.url);
-  } else {
-    popup(login.url);
-  }
+  module.exports.setUrl(login.url);
 };
 
 /**

--- a/login/login.js
+++ b/login/login.js
@@ -26,6 +26,11 @@ function linkify (fanclub, scope, processor) {
     if (url.match('login')) {
       event.preventDefault();
       module.exports.prompt(fanclub, url, processor);
+    } else if (url.match('logout')) {
+      sessionStorage.removeItem('universeAccessToken');
+      sessionStorage.removeItem('universeAccessTokenExpiration');
+      sessionStorage.removeItem('universeRefreshToken');
+      sessionStorage.removeItem('universeRefreshTokenExpiration');
     }
   });
 };

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "browserstack-webdriver": "~2.41.1",
     "browserstacktunnel-wrapper": "^2.0.1",
+    "chalk": "^1.1.3",
     "gulp": "~3.8.8",
     "gulp-browserify": "~0.5.0",
     "gulp-derequire": "~2.0.0",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "solidus-client": "^1.3.5"
   },
   "devDependencies": {
-    "browserstack-webdriver": "~2.41.1",
-    "browserstacktunnel-wrapper": "^2.0.1",
+    "browserstack-local": "^1.4.5",
     "chalk": "^1.1.3",
     "gulp": "~3.8.8",
     "gulp-browserify": "~0.5.0",
@@ -40,6 +39,7 @@
     "handlebars": "~2.0.0",
     "nock": "~0.48.0",
     "run-sequence": "~1.0.1",
+    "selenium-webdriver": "^4.0.0-alpha.7",
     "sinon": "^1.14.1",
     "underscore": "~1.7.0"
   }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "test-server": "./node_modules/.bin/gulp test-server"
   },
   "dependencies": {
-    "cookie": "^0.1.2",
     "dom-delegate": "^2.0.3",
     "query-string": "^2.1.0",
     "solidus-client": "^1.3.5"

--- a/test/browser-test.js
+++ b/test/browser-test.js
@@ -60,7 +60,7 @@ setups.forEach(function (setup) {
     });
 
     test.it('runs the mocha tests', function() {
-      driver.get(config.host + '/test/browser/test.html');
+      driver.get(config.testPage);
       driver.wait(function() {
         return driver.executeScript('return mocha_finished;').then(function(finished) {
           if (!finished) return false;

--- a/test/browser-test.js
+++ b/test/browser-test.js
@@ -1,86 +1,91 @@
 var assert = require('assert');
-var fs = require('fs');
-var webdriver = require('browserstack-webdriver');
-var test = require('browserstack-webdriver/testing');
+var webdriver = require('selenium-webdriver');
 var _ = require('underscore');
 
 var config = require('./config');
 
 var browserStackConfig = {
-  'browserstack.local': 'true',
-  'browserstack.user':  'TODO',
+  'browserstack.local': true,
+  'browserstack.user':  'sparkart',
   'browserstack.key':   'TODO',
-  'project':            'universe-js'
+  'name':               'universe-js'
 }
 
 var setups = [
-  {browserName: 'Chrome'},
-  {browserName: 'Safari', browser_version: '11.0'},
-  {browserName: 'Safari', browser_version: '10.1'},
-  {browserName: 'Safari', browser_version: '9.1'},
-  {browserName: 'IE', browser_version: '11.0'},
-  {browserName: 'IE', browser_version: '10.0'},
-  {browserName: 'IE', browser_version: '9.0'},
-  {browserName: 'Edge', browser_version: '16.0'},
-  {browserName: 'Edge', browser_version: '15.0'},
-  {browserName: 'Edge', browser_version: '14.0'},
-  {browserName: 'Firefox'},
-  {browserName: 'Opera'},
-  {device: 'iPhone X', realMobile: true},
-  {device: 'iPhone 8', realMobile: true},
-  {device: 'iPhone 7', realMobile: true},
-  {device: 'iPad 5th', realMobile: true},
-  {device: 'Samsung Galaxy Note 8', realMobile: true},
-  {device: 'Samsung Galaxy S8', realMobile: true},
-  {device: 'Samsung Galaxy S7', realMobile: true},
-  {device: 'Samsung Galaxy S6', realMobile: true},
-  {device: 'Samsung Galaxy Note 4', realMobile: true},
-  {device: 'Motorola Moto X 2nd Gen', realMobile: true},
-  {device: 'Motorola Moto X 2nd Gen', os_version: '5.0', realMobile: true},
-  {device: 'Google Pixel', realMobile: true},
-  {device: 'Google Pixel', os_version: '7.1', realMobile: true},
-  {device: 'Google Nexus 6', realMobile: true},
-  {device: 'Google Nexus 5', realMobile: true},
-  {device: 'Google Nexus 9', realMobile: true}
+  // https://caniuse.com/usage-table
+  {browserName: 'IE', browser_version: '11.0'}, // TODO: localStorage seems very unreliable on IE
+  {browserName: 'Edge', browser_version: '18.0'},
+  {browserName: 'Edge', browser_version: '17.0'},
+  {browserName: 'Firefox', browser_version: '76.0'},
+  {browserName: 'Firefox', browser_version: '75.0'},
+  {browserName: 'Chrome', browser_version: '83'},
+  {browserName: 'Chrome', browser_version: '81'},
+  {browserName: 'Chrome', browser_version: '80'},
+  {browserName: 'Chrome', browser_version: '79'},
+  {browserName: 'Chrome', browser_version: '78'},
+  {browserName: 'Safari', browser_version: '13.1'},
+  {browserName: 'Safari', browser_version: '13.0'},
+  {browserName: 'Safari', browser_version: '12.1'},
+  {browserName: 'Safari', browser_version: '11.1'},
+  {browserName: 'Opera', browser_version: '12.15'},
+
+  // https://www.browserstack.com/test-on-the-right-mobile-devices
+  // {device: 'iPhone 8', os_version: '13.0', realMobile: true},
+  // {device: 'iPhone XR', os_version: '12.0', realMobile: true},
+  // {device: 'Google Pixel 3', os_version: '9.0', realMobile: true},
+  // {device: 'Samsung Galaxy S9 Plus', os_version: '8.0', realMobile: true},
+  // {device: 'Samsung Galaxy S8', os_version: '7.0', realMobile: true},
+  // {device: 'iPad 6th', os_version: '11.0', realMobile: true},
+  // {device: 'iPhone 8 Plus', os_version: '12.0', realMobile: true},
+  // {device: 'iPhone 6S', os_version: '12.0', realMobile: true},
+  // {device: 'Google Pixel 4', os_version: '10.0', realMobile: true},
+  // {device: 'Huawei P20 Lite', os_version: '9.0', realMobile: true},
+  // {device: 'Samsung Galaxy J7 Prime', os_version: '7.0', realMobile: true},
+  // {device: 'Samsung Galaxy A8', os_version: '7.0', realMobile: true},
+  // {device: 'Samsung Galaxy J5 Prime', os_version: '6.0', realMobile: true},
+  // {device: 'Samsung Galaxy Tab S4', os_version: '8.0', realMobile: true}
 ];
 
 setups.forEach(function (setup) {
-  test.describe(_.compact([setup.device, setup.os_version, setup.browserName, setup.browser_version]).join(', '), function() {
+  describe(_.compact([setup.device, setup.os_version, setup.browserName, setup.browser_version]).join(', '), function() {
     var driver;
 
-    test.before(function() {
+    before(function() {
       driver = new webdriver.Builder()
-        .usingServer('http://hub.browserstack.com/wd/hub')
+        .usingServer('http://hub-cloud.browserstack.com/wd/hub')
         .withCapabilities(_.extend({}, browserStackConfig, setup))
         .build();
     });
 
-    test.after(function() {
+    after(function() {
       driver.quit();
     });
 
-    test.it('runs the mocha tests', function() {
-      driver.get(config.testPage);
-      driver.wait(function() {
-        return driver.executeScript('return mocha_finished;').then(function(finished) {
-          if (!finished) return false;
+    it('runs the mocha tests', async done => {
+      let err;
+      await driver.get(config.testPage);
+      await driver.wait(async () => {
+        const finished = await driver.executeScript('return (typeof mocha_finished !== "undefined") && mocha_finished');
+        if (!finished) return false;
 
-          return driver.executeScript('return mocha_stats;').then(function(stats) {
-            console.log('    Passes: ' + stats.passes + ', Failures: ' + stats.failures + ', Duration: ' + (stats.duration / 1000).toFixed(2) + 's');
-            assert(stats.tests > 0, 'No mocha tests were run');
-            if (!stats.failures) return true;
+        const stats = await driver.executeScript('return mocha_stats');
+        console.log('    Passes: ' + stats.passes + ', Failures: ' + stats.failures + ', Duration: ' + (stats.duration / 1000).toFixed(2) + 's');
 
-            return driver.executeScript('return mocha_failures;').then(function(failures) {
-              for (var i = 0; i < failures.length; ++i) {
-                var prefix = '    ' + (i + 1) + '. ';
-                console.log(prefix + failures[i][0]);
-                console.log(Array(prefix.length + 1).join(' ') + failures[i][1]);
-              }
-              return true;
-            });
-          });
-        });
+        if (!stats.tests) {
+          err = new Error('Failed to run tests');
+        } else if (stats.failures) {
+          err = new Error(`${stats.failures} tests failed`);
+          const failures = await driver.executeScript('return mocha_failures');
+          for (var i = 0; i < failures.length; ++i) {
+            var prefix = '    ' + (i + 1) + '. ';
+            console.log(prefix + failures[i][0]);
+            console.log(Array(prefix.length + 1).join(' ') + failures[i][1]);
+          }
+        }
+
+        return true;
       });
+      done(err);
     });
   });
 });

--- a/test/browser/functional.html
+++ b/test/browser/functional.html
@@ -1,0 +1,11 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Functional Tests</title>
+  <link rel="stylesheet" href="mocha.css" />
+  <script src="functional.js"></script>
+</head>
+<body>
+</body>
+</html>

--- a/test/config.js
+++ b/test/config.js
@@ -27,7 +27,7 @@ module.exports.routes = function (req, res) {
   var success = function(data) {
     res.writeHead(200, {
       'Content-Type': 'application/json',
-      'Access-Control-Allow-Origin': req.headers.origin,
+      'Access-Control-Allow-Origin': req.headers.origin || module.exports.testHost,
       'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
       'Access-Control-Allow-Credentials': true,
       'Access-Control-Allow-Headers': 'Authorization, Content-Type',

--- a/test/config.js
+++ b/test/config.js
@@ -6,6 +6,10 @@ module.exports.port = 8081;
 module.exports.host = 'http://localhost:' + module.exports.port;
 module.exports.testHost = 'http://lvh.me:' + module.exports.port;
 module.exports.testPage = module.exports.testHost + '/test/browser/test.html';
+module.exports.accessTokenExpiration = 15 * 60;
+module.exports.accessTokenExpirationMs = module.exports.accessTokenExpiration * 1000;
+module.exports.refreshTokenExpiration = 24 * 60 * 60;
+module.exports.refreshTokenExpirationMs = module.exports.refreshTokenExpiration * 1000;
 
 module.exports.routes = function (req, res) {
   if (req.url.indexOf('/test/browser/') == 0) {
@@ -23,7 +27,7 @@ module.exports.routes = function (req, res) {
   var success = function(data) {
     res.writeHead(200, {
       'Content-Type': 'application/json',
-      'Access-Control-Allow-Origin': module.exports.testHost,
+      'Access-Control-Allow-Origin': req.headers.origin,
       'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
       'Access-Control-Allow-Credentials': true,
       'Access-Control-Allow-Headers': 'Authorization, Content-Type',
@@ -90,9 +94,9 @@ module.exports.routes = function (req, res) {
           status: 'ok',
           access: {
             access_token: 'valid_access_token_2',
-            access_token_expiration: now + 5,
+            access_token_expiration: now + module.exports.accessTokenExpiration,
             refresh_token: 'valid_refresh_token_2',
-            refresh_token_expiration: now + 50
+            refresh_token_expiration: now + module.exports.refreshTokenExpiration
           }
         });
       } else if (body == '{"refresh_token":"oh no"}') {

--- a/test/config.js
+++ b/test/config.js
@@ -1,11 +1,12 @@
 var fs = require('fs');
 var url  = require('url');
 
-// Server runs on localhost and test page runs on lvh.me, to test cross-domain requests
+// Server runs on universe-js.test and test page runs on lvh.me, to test cross-domain requests
 module.exports.port = 8081;
-module.exports.host = 'http://localhost:' + module.exports.port;
+module.exports.host = 'http://universe-js.test:' + module.exports.port;
 module.exports.testHost = 'http://lvh.me:' + module.exports.port;
 module.exports.testPage = module.exports.testHost + '/test/browser/test.html';
+module.exports.functionalTestPage = module.exports.testHost + '/test/browser/functional.html';
 module.exports.accessTokenExpiration = 15 * 60;
 module.exports.accessTokenExpirationMs = module.exports.accessTokenExpiration * 1000;
 module.exports.refreshTokenExpiration = 24 * 60 * 60;
@@ -19,6 +20,14 @@ module.exports.routes = function (req, res) {
       else if (/\.js$/.test(req.url)) content_type = 'text/javascript';
       else content_type = 'text/html';
       res.writeHead(200, {'Content-Type': content_type});
+      res.end(err || data);
+    });
+    return;
+  }
+
+  if (req.url.indexOf('/login/reload') == 0) {
+    fs.readFile('./login/closePromptPopup.hbs', function(err, data) {
+      res.writeHead(200, {'Content-Type': 'text/html'});
       res.end(err || data);
     });
     return;
@@ -50,7 +59,9 @@ module.exports.routes = function (req, res) {
 
   if (req.method === 'OPTIONS') return success();
 
-  switch ((req.method + ' ' + req.url).replace(/solidus_client_jsonp_callback_\d+/, 'solidus_client_jsonp_callback')) {
+  switch ((req.method + ' ' + req.url)
+    .replace(/solidus_client_jsonp_callback_\d+/, 'solidus_client_jsonp_callback')
+    .replace(/redirect=[^&#$]+/, 'redirect=')) {
   case 'GET /api/v1/fanclub?key=12345':
   case 'GET /api/v1/fanclub?key=12345&callback=solidus_client_jsonp_callback':
     success({fanclub: 'demo!'});
@@ -106,6 +117,26 @@ module.exports.routes = function (req, res) {
         success({status: 'error', messages: ['Unable to decode refresh token']});
       }
     });
+    break;
+
+  case 'GET /1/login?popup=1&redirect=':
+    var now = Math.round(new Date().getTime() / 1000);
+    var location = [
+      req.headers.origin || module.exports.testHost,
+      '/login/reload?access_token=valid_access_token&access_token_expiration=',
+      now + module.exports.accessTokenExpiration,
+      '&refresh_token=valid_refresh_token&refresh_token_expiration=',
+      now + module.exports.refreshTokenExpiration,
+      '&redirect=',
+      encodeURIComponent(url.parse(req.url, true).query.redirect || '')
+    ].join('');
+    res.writeHead(301, {Location: location});
+    res.end();
+    break;
+
+  case 'GET /1/logout?redirect=':
+    res.writeHead(301, {Location: url.parse(req.url, true).query.redirect || req.headers.origin || module.exports.testHost});
+    res.end();
     break;
 
   default:

--- a/test/config.js
+++ b/test/config.js
@@ -1,9 +1,11 @@
 var fs = require('fs');
 var url  = require('url');
 
-// Safari doesn't like localhost, see https://www.browserstack.com/question/663
+// Server runs on localhost and test page runs on lvh.me, to test cross-domain requests
 module.exports.port = 8081;
-module.exports.host = 'http://lvh.me:' + module.exports.port;
+module.exports.host = 'http://localhost:' + module.exports.port;
+module.exports.testHost = 'http://lvh.me:' + module.exports.port;
+module.exports.testPage = module.exports.testHost + '/test/browser/test.html';
 
 module.exports.routes = function (req, res) {
   if (req.url.indexOf('/test/browser/') == 0) {
@@ -19,7 +21,14 @@ module.exports.routes = function (req, res) {
   }
 
   var success = function(data) {
-    res.writeHead(200, {'Content-Type': 'application/json'});
+    res.writeHead(200, {
+      'Content-Type': 'application/json',
+      'Access-Control-Allow-Origin': module.exports.testHost,
+      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+      'Access-Control-Allow-Credentials': true,
+      'Access-Control-Allow-Headers': 'Authorization, Content-Type',
+      'Access-Control-Max-Age': '1728000'
+    });
     var callback = url.parse(req.url, true).query.callback;
     if (callback) {
       res.end(callback + '(' + JSON.stringify(data) + ');');
@@ -34,6 +43,8 @@ module.exports.routes = function (req, res) {
   };
 
   var logged_in = req.headers.authorization && req.headers.authorization.match(/^Bearer valid_access_token(_\d+)?$/);
+
+  if (req.method === 'OPTIONS') return success();
 
   switch ((req.method + ' ' + req.url).replace(/solidus_client_jsonp_callback_\d+/, 'solidus_client_jsonp_callback')) {
   case 'GET /api/v1/fanclub?key=12345':
@@ -69,21 +80,28 @@ module.exports.routes = function (req, res) {
     success({status: 'ok', customer: {id: 1, email: 'test@sparkart.com'}});
     break;
 
-  case 'POST /api/v1/login/refresh?key=12345':
-    if (req.headers['x-refresh-token'] === 'valid_refresh_token') {
-      var now = new Date().getTime();
-      success({
-        access_token: 'valid_access_token_2',
-        access_token_expires_at: now + 5000,
-        refresh_token: 'valid_refresh_token_2',
-        refresh_token_expires_at: now + 50000
-      });
-    } else if (req.headers['x-refresh-token'] === 'oh no') {
-      not_found();
-    } else {
-      res.writeHead(401, {'Content-Type': 'application/json'});
-      res.end(JSON.stringify({error: 'Invalid refresh token'}));
-    }
+  case 'POST /api/v1/refresh?key=12345':
+    var body = '';
+    req.on('data', function(data) {body += data;});
+    req.on('end', function() {
+      if (body == '{"refresh_token":"valid_refresh_token"}') {
+        var now = new Date().getTime() / 1000;
+        success({
+          status: 'ok',
+          access: {
+            access_token: 'valid_access_token_2',
+            access_token_expiration: now + 5,
+            refresh_token: 'valid_refresh_token_2',
+            refresh_token_expiration: now + 50
+          }
+        });
+      } else if (body == '{"refresh_token":"oh no"}') {
+        // To test errors not related to bad refresh tokens
+        not_found();
+      } else {
+        success({status: 'error', messages: ['Unable to decode refresh token']});
+      }
+    });
     break;
 
   default:

--- a/test/config.js
+++ b/test/config.js
@@ -33,9 +33,9 @@ module.exports.routes = function (req, res) {
     res.end(JSON.stringify({error: 'Not Found: ' + req.url}));
   };
 
-  var logged_in = req.url.indexOf('/i/') == 0;
+  var logged_in = req.headers.authorization && req.headers.authorization.match(/^Bearer valid_access_token(_\d+)?$/);
 
-  switch ((req.method + ' ' + req.url.substring(2)).replace(/solidus_client_jsonp_callback_\d+/, 'solidus_client_jsonp_callback')) {
+  switch ((req.method + ' ' + req.url).replace(/solidus_client_jsonp_callback_\d+/, 'solidus_client_jsonp_callback')) {
   case 'GET /api/v1/fanclub?key=12345':
   case 'GET /api/v1/fanclub?key=12345&callback=solidus_client_jsonp_callback':
     success({fanclub: 'demo!'});
@@ -67,6 +67,23 @@ module.exports.routes = function (req, res) {
 
   case 'GET /api/v1/account?key=12345&_method=POST&callback=solidus_client_jsonp_callback&id=1&email=test%40sparkart.com':
     success({status: 'ok', customer: {id: 1, email: 'test@sparkart.com'}});
+    break;
+
+  case 'POST /api/v1/login/refresh?key=12345':
+    if (req.headers['x-refresh-token'] === 'valid_refresh_token') {
+      var now = new Date().getTime();
+      success({
+        access_token: 'valid_access_token_2',
+        access_token_expires_at: now + 5000,
+        refresh_token: 'valid_refresh_token_2',
+        refresh_token_expires_at: now + 50000
+      });
+    } else if (req.headers['x-refresh-token'] === 'oh no') {
+      not_found();
+    } else {
+      res.writeHead(401, {'Content-Type': 'application/json'});
+      res.end(JSON.stringify({error: 'Invalid refresh token'}));
+    }
     break;
 
   default:

--- a/test/tests/functional.js
+++ b/test/tests/functional.js
@@ -1,0 +1,23 @@
+const universejs = require('../../')({environment: 'test', key: '12345'});
+const login = require('../../login');
+
+window.universeStatus = undefined;
+
+universejs.init(function(err, data) {
+  if (err) throw err;
+
+  // Create a Log In / Log Out link
+  const a = document.createElement('a');
+  a.id = 'universeButton';
+  const linkText = document.createTextNode(data.customer ? 'Log Out' : 'Log In');
+  a.appendChild(linkText);
+  a.title = data.customer ? 'Log Out' : 'Log In';
+  a.href = (data.customer ? '//universe-js.test:8081/1/logout?redirect=' : 'login?redirect=') + encodeURIComponent(window.location.href);
+  document.body.appendChild(a);
+
+  // Linkify it
+  login.linkify({links: {login: '//universe-js.test:8081/1/login'}});
+
+  // Tell browser-test.js we're done
+  window.universeStatus = data.customer ? 'logged in' : 'logged out';
+});

--- a/test/tests/login.js
+++ b/test/tests/login.js
@@ -18,19 +18,19 @@ describe('Login', function() {
   var sandbox;
   var mock;
 
-  const tokensLogin = () => {
+  function tokensLogin() {
     localStorage.setItem('universeAccessToken', 'valid_access_token');
     localStorage.setItem('universeAccessTokenExpiration', '12345');
     localStorage.setItem('universeRefreshToken', 'valid_refresh_token');
     localStorage.setItem('universeRefreshTokenExpiration', '54321');
-  };
+  }
 
-  const tokensLogout = () => {
+  function tokensLogout() {
     localStorage.removeItem('universeAccessToken');
     localStorage.removeItem('universeAccessTokenExpiration');
     localStorage.removeItem('universeRefreshToken');
     localStorage.removeItem('universeRefreshTokenExpiration');
-  };
+  }
 
   beforeEach(function() {
     sandbox = sinon.sandbox.create();

--- a/test/tests/login.js
+++ b/test/tests/login.js
@@ -19,17 +19,17 @@ describe('Login', function() {
   var mock;
 
   const tokensLogin = () => {
-    sessionStorage.setItem('universeAccessToken', 'valid_access_token');
-    sessionStorage.setItem('universeAccessTokenExpiration', '12345');
-    sessionStorage.setItem('universeRefreshToken', 'valid_refresh_token');
-    sessionStorage.setItem('universeRefreshTokenExpiration', '54321');
+    localStorage.setItem('universeAccessToken', 'valid_access_token');
+    localStorage.setItem('universeAccessTokenExpiration', '12345');
+    localStorage.setItem('universeRefreshToken', 'valid_refresh_token');
+    localStorage.setItem('universeRefreshTokenExpiration', '54321');
   };
 
   const tokensLogout = () => {
-    sessionStorage.removeItem('universeAccessToken');
-    sessionStorage.removeItem('universeAccessTokenExpiration');
-    sessionStorage.removeItem('universeRefreshToken');
-    sessionStorage.removeItem('universeRefreshTokenExpiration');
+    localStorage.removeItem('universeAccessToken');
+    localStorage.removeItem('universeAccessTokenExpiration');
+    localStorage.removeItem('universeRefreshToken');
+    localStorage.removeItem('universeRefreshTokenExpiration');
   };
 
   beforeEach(function() {
@@ -95,10 +95,10 @@ describe('Login', function() {
       var delegate = new Delegate(div);
       delegate.on('click', 'a', function (event) {
         event.preventDefault();
-        assert.equal(sessionStorage.getItem('universeAccessToken'), null);
-        assert.equal(sessionStorage.getItem('universeAccessTokenExpiration'), null);
-        assert.equal(sessionStorage.getItem('universeRefreshToken'), null);
-        assert.equal(sessionStorage.getItem('universeRefreshTokenExpiration'), null);
+        assert.equal(localStorage.getItem('universeAccessToken'), null);
+        assert.equal(localStorage.getItem('universeAccessTokenExpiration'), null);
+        assert.equal(localStorage.getItem('universeRefreshToken'), null);
+        assert.equal(localStorage.getItem('universeRefreshTokenExpiration'), null);
         done();
       });
 
@@ -118,10 +118,10 @@ describe('Login', function() {
       var delegate = new Delegate(div);
       delegate.on('click', 'a', function (event) {
         event.preventDefault();
-        assert.equal(sessionStorage.getItem('universeAccessToken'), 'valid_access_token');
-        assert.equal(sessionStorage.getItem('universeAccessTokenExpiration'), '12345');
-        assert.equal(sessionStorage.getItem('universeRefreshToken'), 'valid_refresh_token');
-        assert.equal(sessionStorage.getItem('universeRefreshTokenExpiration'), '54321');
+        assert.equal(localStorage.getItem('universeAccessToken'), 'valid_access_token');
+        assert.equal(localStorage.getItem('universeAccessTokenExpiration'), '12345');
+        assert.equal(localStorage.getItem('universeRefreshToken'), 'valid_refresh_token');
+        assert.equal(localStorage.getItem('universeRefreshTokenExpiration'), '54321');
         done();
       });
 
@@ -131,7 +131,7 @@ describe('Login', function() {
 
   describe('.prompt', function() {
     var expectRedirect = function(options) {
-      options.redirect || (options.redirect = config.host + '/');
+      options.redirect || (options.redirect = config.testHost + '/');
       options.popup = 1;
       mock.expects('setLoginRedirect').withArgs(options.redirect).twice();
 
@@ -161,7 +161,7 @@ describe('Login', function() {
     });
 
     it('with relative redirect', function(done) {
-      expectRedirect({redirect: config.host + '/test/browser/redir'});
+      expectRedirect({redirect: config.testHost + '/test/browser/redir'});
 
       login.prompt(fanclub, '/login?redirect=redir');
       login.prompt(fanclub, {redirect: 'redir'});
@@ -169,7 +169,7 @@ describe('Login', function() {
     });
 
     it('with absolute redirect', function(done) {
-      expectRedirect({redirect: config.host + '/redir'});
+      expectRedirect({redirect: config.testHost + '/redir'});
 
       login.prompt(fanclub, '/login?redirect=/redir');
       login.prompt(fanclub, {redirect: '/redir'});
@@ -188,7 +188,7 @@ describe('Login', function() {
       var processor = function(options) {
         assert.equal(options.a, '1');
         assert.equal(options.z, '2');
-        assert.equal(options.redirect, config.host + '/redir');
+        assert.equal(options.redirect, config.testHost + '/redir');
         options.z = 3;
         options.redirect = 'http://somesite.com';
         return options;

--- a/test/tests/login.js
+++ b/test/tests/login.js
@@ -88,15 +88,14 @@ describe('Login', function() {
   describe('.prompt', function() {
     var expectRedirect = function(options) {
       options.redirect || (options.redirect = config.host + '/');
+      options.popup = 1;
+      mock.expects('setLoginRedirect').withArgs(options.redirect).twice();
 
       if (util.isMobile) {
         mock.expects('setUrl').withArgs(fanclub.links.login + '?' + qs.stringify(options)).twice();
-        mock.expects('setCookie').never();
         mock.expects('openUrl').never();
       } else {
-        options.popup = 1;
         mock.expects('setUrl').never();
-        mock.expects('setCookie').withArgs(options.redirect).twice();
         mock.expects('openUrl').withArgs(fanclub.links.login + '?' + qs.stringify(options)).twice();
       }
     };

--- a/test/tests/login.js
+++ b/test/tests/login.js
@@ -3,7 +3,6 @@ var sinon = require('sinon');
 var qs = require('query-string');
 var Delegate = require('dom-delegate');
 
-var util = require('../../lib/util');
 var login = require('../../login');
 var config = require('../config');
 
@@ -135,13 +134,8 @@ describe('Login', function() {
       options.popup = 1;
       mock.expects('setLoginRedirect').withArgs(options.redirect).twice();
 
-      if (util.isMobile) {
-        mock.expects('setUrl').withArgs(fanclub.links.login + '?' + qs.stringify(options)).twice();
-        mock.expects('openUrl').never();
-      } else {
-        mock.expects('setUrl').never();
-        mock.expects('openUrl').withArgs(fanclub.links.login + '?' + qs.stringify(options)).twice();
-      }
+      mock.expects('setUrl').withArgs(fanclub.links.login + '?' + qs.stringify(options)).twice();
+      mock.expects('openUrl').never();
     };
 
     it('redirects to Universe login url', function(done) {

--- a/test/tests/universe-js.js
+++ b/test/tests/universe-js.js
@@ -8,25 +8,25 @@ var config = require('../config');
 if (require('solidus-client/lib/util').isNode) {
   global.localStorage = {
     storage: {},
-    setItem: (k, v) => localStorage.storage[k] = v,
-    getItem: k => localStorage.storage[k],
-    removeItem: k => delete localStorage.storage[k]
+    setItem: function(k, v) {localStorage.storage[k] = v},
+    getItem: function(k) {return localStorage.storage[k]},
+    removeItem: function(k) {delete localStorage.storage[k]}
   };
 }
 
-const login = () => {
+function login() {
   localStorage.setItem('universeAccessToken', 'valid_access_token');
-  localStorage.setItem('universeAccessTokenExpiration', (new Date().getTime() + 5000).toString());
+  localStorage.setItem('universeAccessTokenExpiration', (new Date().getTime() + config.accessTokenExpirationMs).toString());
   localStorage.setItem('universeRefreshToken', 'valid_refresh_token');
-  localStorage.setItem('universeRefreshTokenExpiration', (new Date().getTime() + 50000).toString());
-};
+  localStorage.setItem('universeRefreshTokenExpiration', (new Date().getTime() + config.refreshTokenExpirationMs).toString());
+}
 
-const logout = () => {
+function logout() {
   localStorage.removeItem('universeAccessToken');
   localStorage.removeItem('universeAccessTokenExpiration');
   localStorage.removeItem('universeRefreshToken');
   localStorage.removeItem('universeRefreshTokenExpiration');
-};
+}
 
 module.exports = function() {
 
@@ -207,10 +207,8 @@ describe('Universe', function() {
         assert.deepEqual(data, {customer: 'me!'});
         assert.equal(localStorage.getItem('universeAccessToken'), 'valid_access_token_2');
         assert(localStorage.getItem('universeAccessTokenExpiration') > new Date().getTime());
-        assert(localStorage.getItem('universeAccessTokenExpiration') < new Date().getTime() + 6000);
         assert.equal(localStorage.getItem('universeRefreshToken'), 'valid_refresh_token_2');
         assert(localStorage.getItem('universeRefreshTokenExpiration') > new Date().getTime());
-        assert(localStorage.getItem('universeRefreshTokenExpiration') < new Date().getTime() + 51000);
         done();
       });
     });
@@ -223,10 +221,8 @@ describe('Universe', function() {
         assert.deepEqual(data, {customer: 'me!'});
         assert.equal(localStorage.getItem('universeAccessToken'), 'valid_access_token_2');
         assert(localStorage.getItem('universeAccessTokenExpiration') > new Date().getTime());
-        assert(localStorage.getItem('universeAccessTokenExpiration') < new Date().getTime() + 6000);
         assert.equal(localStorage.getItem('universeRefreshToken'), 'valid_refresh_token_2');
         assert(localStorage.getItem('universeRefreshTokenExpiration') > new Date().getTime());
-        assert(localStorage.getItem('universeRefreshTokenExpiration') < new Date().getTime() + 51000);
         done();
       });
     });
@@ -239,10 +235,8 @@ describe('Universe', function() {
         assert.deepEqual(data, {});
         assert.equal(localStorage.getItem('universeAccessToken'), 'invalid_access_token');
         assert(localStorage.getItem('universeAccessTokenExpiration') > new Date().getTime());
-        assert(localStorage.getItem('universeAccessTokenExpiration') < new Date().getTime() + 6000);
         assert.equal(localStorage.getItem('universeRefreshToken'), 'valid_refresh_token');
         assert(localStorage.getItem('universeRefreshTokenExpiration') > new Date().getTime());
-        assert(localStorage.getItem('universeRefreshTokenExpiration') < new Date().getTime() + 51000);
         done();
       });
     });
@@ -303,7 +297,6 @@ describe('Universe', function() {
         assert(!localStorage.getItem('universeAccessTokenExpiration'));
         assert.equal(localStorage.getItem('universeRefreshToken'), 'oh no');
         assert(localStorage.getItem('universeRefreshTokenExpiration') > new Date().getTime());
-        assert(localStorage.getItem('universeRefreshTokenExpiration') < new Date().getTime() + 51000);
         done();
       });
     });


### PR DESCRIPTION
Thanks to Safari, third-party cookies are mostly blocked now: https://webkit.org/blog/10218/full-third-party-cookie-blocking-and-more/

This pull request handles the user sessions with JWTs stored in `localStorage`, instead of relying on the Universe cookie. The popup login window has also been removed, in favour of simple redirects.